### PR TITLE
feat: connected frontend to a backend cover letter template endpoint

### DIFF
--- a/CareerKitBackend/Program.cs
+++ b/CareerKitBackend/Program.cs
@@ -6,16 +6,22 @@ using CareerKitBackend.Main.InterviewService.Service;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+// Add services to the container.
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
 builder.Services.AddControllers();
+builder.Services.AddSwaggerGen();
+
+// External services
 builder.Services.AddOpenAIService(); // Loads from config (e.g., appsettings or Render env vars)
+
+// Internal services (Scoped)
 builder.Services.AddScoped<OpenAIService>();
 builder.Services.AddScoped<CoverLetterService>();
-builder.Services.AddSingleton<TrackerService>();
 builder.Services.AddScoped<InterviewService>();
+
+// Internal services (Singleton)
+builder.Services.AddSingleton<TrackerService>();
 
 var app = builder.Build();
 

--- a/CareerKitBackend/Program.cs
+++ b/CareerKitBackend/Program.cs
@@ -23,6 +23,18 @@ builder.Services.AddScoped<InterviewService>();
 // Internal services (Singleton)
 builder.Services.AddSingleton<TrackerService>();
 
+// CORS
+builder.Services.AddCors(options =>
+{
+	options.AddDefaultPolicy(policy =>
+	{
+		policy
+			.WithOrigins("http://127.0.0.1:5500") // frontend local origins
+			.AllowAnyHeader()
+			.AllowAnyMethod();
+	});
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -31,6 +43,8 @@ if (app.Environment.IsDevelopment())
 	app.UseSwagger();
 	app.UseSwaggerUI();
 }
+
+app.UseCors(); // Enable CORS before routing
 
 app.UseHttpsRedirection();
 


### PR DESCRIPTION
- added "CORS" service to allow local development for frontend local origins
- "CORS" must be enabled before any routing occurs, namely app.UseCors() before app.MapControllers()
- styled Program.cs by grouping logically related elements together for clarity